### PR TITLE
Don't write the registry-file directly, but move a tmpfile on success

### DIFF
--- a/gebuilder/example_hooks/openstack_image/60-upload_image.sh
+++ b/gebuilder/example_hooks/openstack_image/60-upload_image.sh
@@ -24,5 +24,8 @@ fi
 # Calling `cleanup` here patches https://github.com/IBT-FMI/gebuilder/issues/11
 cleanup
 debug "Uploading new image with name $OS_IMGNAME"
-gl image-create --disk-format raw --container-format bare --name "$OS_IMGNAME" --file "$OPENSTACK_IMAGE" >"${ROOT}/../registry/openstack_image"
-
+regfile="${ROOT}/../registry/openstack_image"
+gl image-create --disk-format raw --container-format bare --name "$OS_IMGNAME" --file "$OPENSTACK_IMAGE" \
+	>"${regfile}.tmp"\
+	&& mv "${regfile}.tmp" "${regfile}"\
+	|| (rm "${regfile}.tmp"; false)


### PR DESCRIPTION
This allows for the command to fail without modifying the state of the registry.
Addresses issue #27, where a failed glance-command results in the next call looking
for an ID of '' (empty-string)